### PR TITLE
Explicitly set the shell to use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ TARGETS=linux_amd64 darwin_amd64 freebsd_amd64 netbsd_amd64 openbsd_amd64 window
 VERSION=`git describe --tags`
 FLAGS=-ldflags "-s -w -X 'main.Version=${VERSION}'" -trimpath
 ENVS=GO111MODULES=on CGO_ENABLED=0
+SHELL=/usr/bin/env bash
 
 all: install
 

--- a/cmd/minify/bash_completion
+++ b/cmd/minify/bash_completion
@@ -1,6 +1,7 @@
-#!/bin/sh
+# If not running interactively, don't do anything
+[[ $- != *i* ]] && return 0
 
-if [ ! -z "$ZSH_NAME" ]; then 
+if [[ -n "${ZSH_NAME:-}" ]]; then
     # zsh sets $ZSH_NAME variable so it can be used to detect zsh
     # following enables using bash-completion under zsh
     autoload bashcompinit
@@ -17,11 +18,11 @@ _minify_complete() {
     types="css html js json svg xml"
 
     if [[ ${cur} == -* ]] ; then
-        COMPREPLY=( $(compgen -W "${flags}" -- ${cur}) )
+        COMPREPLY=( $(compgen -W "${flags}" -- "${cur}") )
     elif [[ ${prev} =~ ^--mime$ ]] ; then
-        COMPREPLY=( $(compgen -W "${mimes}" -- ${cur}) )
+        COMPREPLY=( $(compgen -W "${mimes}" -- "${cur}") )
     elif [[ ${prev} =~ ^--type$ ]] ; then
-        COMPREPLY=( $(compgen -W "${types}" -- ${cur}) )
+        COMPREPLY=( $(compgen -W "${types}" -- "${cur}") )
     elif [[ ${prev} =~ ^--(match|url|css-precision|js-precision|json-precision|svg-precision|cpuprofile|memprofile)$ ]] ; then
         compopt +o default
         COMPREPLY=()
@@ -33,3 +34,4 @@ _minify_complete() {
 }
 
 complete -F _minify_complete minify
+


### PR DESCRIPTION
Without explicitly settings the SHELL variable the make defaults to /bin/sh which does not play well with cmd/minify/bash_completion